### PR TITLE
fix: zenject findobjectsofType deprecation

### DIFF
--- a/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -101,7 +101,7 @@ namespace Zenject
             ProfileBlock.UnityMainThread = Thread.CurrentThread;
 #endif
 
-            Assert.That(FindObjectsOfType<ProjectContext>().IsEmpty(),
+            Assert.That(FindObjectsByType<ProjectContext>(FindObjectsSortMode.None).IsEmpty(), 
                 "Tried to create multiple instances of ProjectContext!");
 
             var prefab = TryGetPrefab();

--- a/Assets/Plugins/Zenject/Source/Util/UnityUtil.cs
+++ b/Assets/Plugins/Zenject/Source/Util/UnityUtil.cs
@@ -127,7 +127,7 @@ namespace ModestTree.Util
 
         public static IEnumerable<GameObject> GetAllGameObjects()
         {
-            return GameObject.FindObjectsOfType<Transform>().Select(x => x.gameObject);
+            return GameObject.FindObjectsByType<Transform>(FindObjectsSortMode.None).Select(x => x.gameObject);
         }
 
         public static List<GameObject> GetAllRootGameObjects()


### PR DESCRIPTION
Replace deprecated FindObjectsOfType with FindObjectsByType in Zenject